### PR TITLE
feat: Add a helper function that wraps http.handler

### DIFF
--- a/spring-web/spring-web-container.go
+++ b/spring-web/spring-web-container.go
@@ -291,6 +291,14 @@ func HTTP(fn http.HandlerFunc) Handler {
 	return httpHandler(fn)
 }
 
+// WrapH 用于包装 http.Handler 的辅助函数
+func WrapH(handler http.Handler) Handler {
+	return HTTP(func(res http.ResponseWriter, req *http.Request) {
+		handler.ServeHTTP(res, req)
+		return
+	})
+}
+
 /////////////////// Web Filters //////////////////////
 
 var defaultRecoveryFilter = &recoveryFilter{}


### PR DESCRIPTION
Add a helper function that wraps http.handler

So that we can use it like this

```
SpringBoot.HandleGet("/metrics", SpringWeb.WrapH(promhttp.Handler()))
```